### PR TITLE
Revert custom registry install directory for Vulkan SC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,6 @@ if (PROJECT_IS_TOP_LEVEL)
     include(cmake/GenVulkanSCCombined.cmake)
 
     set(VLK_REGISTRY_DIR "${CMAKE_INSTALL_DATADIR}/vulkan")
-    if(VULKANSC)
-        set(VLK_REGISTRY_DIR "${CMAKE_INSTALL_DATADIR}/vulkansc")
-    endif()
 
     # Install header files
     if(NOT VULKANSC)


### PR DESCRIPTION
This turned out to be unnecessary and causes some issues with dependent component builds.

Long story short, this is something I've added as part of my fight with the github CI, but I was wrong to do so, as the CMake package management utilities expect the registry to be installed in the `vulkan` subdirectory.