### PR TITLE
Add helper Makefile to install headers and related files from

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -1,0 +1,97 @@
+# Copyright 2024-2025 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Makefile.release - update external files generated in Vulkan SC spec
+# repository when a public specification update is done.
+# Based on equivalent in Vulkan-Headers, with differences (no Hpp
+# bindings, no profiles, add generated JSON files).
+
+# Needed to get the right version of test, apparently
+SHELL  = /bin/bash
+
+REVISION = 999
+
+# Location of other repository clones
+GIT	 = ..
+SPEC	 = $(GIT)/VulkanSC-Docs
+REGISTRY = $(GIT)/registry/vulkansc
+
+update: version-check create-branch update-files push-branch
+
+# Working branch for the update, and a test if it exists
+BRANCH = update-$(REVISION)
+
+# Switch to new branch which will contain the update
+create-branch: version-check
+	git switch -q main
+	git pull -q
+	# If branch already exists, do nothing
+	@if test `git branch -l $(BRANCH) | wc -l` == 1 ; then \
+	    echo "Branch $(BRANCH) already exists" ; \
+	    git switch $(BRANCH) ; \
+	else \
+	    echo "Creating branch $(BRANCH)" ; \
+	    git switch -c $(BRANCH) ; \
+	fi
+
+# Update headers and scripts in the new branch
+update-files: remove-files update-headers update-scripts
+
+update-headers:
+	if test ! -d $(SPEC)/gen/include/ ; then \
+	    echo "No C header file source directory $(SPEC)/gen/include" ; \
+	    exit 1 ; \
+	fi
+	cp -r $(SPEC)/gen/include/* include/
+	cp $(SPEC)/gen/out/json/*.json json/
+
+# Top-level scripts / XML / json to install in registry directory
+SCRIPTS = \
+    $(SPEC)/scripts/apiconventions.py \
+    $(SPEC)/scripts/base_generator.py \
+    $(SPEC)/scripts/cgenerator.py \
+    $(SPEC)/scripts/generator.py \
+    $(SPEC)/scripts/genvk.py \
+    $(SPEC)/scripts/parse_dependency.py \
+    $(SPEC)/scripts/reflib.py \
+    $(SPEC)/scripts/reg.py \
+    $(SPEC)/scripts/stripAPI.py \
+    $(SPEC)/scripts/vkconventions.py \
+    $(SPEC)/scripts/vulkan_object.py \
+    $(SPEC)/xml/video.xml \
+    $(SPEC)/xml/vk.xml \
+    $(REGISTRY)/specs/1.0-extensions/validation/validusage.json
+
+# Scripts in registry/spec_tools to install
+SCRIPT_TOOLS = \
+    $(SPEC)/scripts/spec_tools/conventions.py \
+    $(SPEC)/scripts/spec_tools/util.py
+
+update-scripts:
+	cp $(SCRIPTS) registry/
+	cp $(SCRIPT_TOOLS) registry/spec_tools/
+
+# To ensure updates are caught, old versions of installed files are
+# removed.
+
+# Files in include/ to keep
+HEADERS_KEEP = \
+    include/vulkan/vk_icd.h \
+    include/vulkan/vk_layer.h
+
+remove-files:
+	rm -rf $(filter-out $(HEADERS_KEEP), $(wildcard include/vulkan/*))
+	rm -rf include/vk_video
+	rm -rf registry
+	mkdir include/vk_video registry registry/spec_tools
+
+# Once the branch is updated, push it to upstream
+# This does not actually push it for safety reasons
+push-branch:
+	@echo Verify that all new files are 'git add'ed and obsolete files removed, then:
+	@echo git commit -m \"Update for VulkanSC-Docs 1.0.$(REVISION)\"
+	@echo git push --set-upstream origin $(BRANCH)
+	@echo git switch main
+
+version-check:
+	@if test $(REVISION) = 999 ; then echo "Must specify explicit REVISION= in make invocation" ; exit 1 ; fi


### PR DESCRIPTION
@aqnuep per the other issue discussion - this simplifies the release mechanics by putting the file list to be published into a Makefile instead of the wiki page, matching what was done in Vulkan-Headers a while back. I had been intending to do this at the next update but your issue pushes it a bit. N.b. not fully tested, yet (hard to test outside of production since it creates new branches and such).