### PR TITLE
Fix typo in Vulkan SC combined headers build documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -15,7 +15,7 @@ cmake --install build --prefix build/install
 
 Build the combined Vulkan SC headers used by ecosystem components as follows:
 ```bash
-cmake -DGEN_VULKANSC_COMBINED -S . -B build/
+cmake -DGEN_VULKANSC_COMBINED=ON -S . -B build/
 cmake --build build
 cmake --install build --prefix build/install
 ```


### PR DESCRIPTION
<!-- Please note when contributing what files this repository actually is responsible for.

VulkanSC-Headers exists as a publishing mechanism for headers and related material sourced from multiple other repositories. If you have a problem with that material, it should *not* be reported here, but in the appropriate repository:

This repository is responsible for the following files

* BUILD.gn
* BUILD.md
* cmake/*
* CMakeLists.txt
* tests/*
* CODE_OF_CONDUCT.md
* LICENSE.txt
* README.md
* Non-API headers
  * include/vulkan/vk_icd.h
  * include/vulkan/vk_layer.h

-->
